### PR TITLE
Name der Uni korrigiert

### DIFF
--- a/beamerthemeACON.sty
+++ b/beamerthemeACON.sty
@@ -49,7 +49,7 @@
   }
   \renewcommand{\contactline}{\structure{Kontaktdaten}}
   \renewcommand{\footchair}{Lehrstuhl f\"ur Regelungstechnik}
-  \renewcommand{\footuniv}{Universit\"at Kiel}
+  \renewcommand{\footuniv}{Christian-Albrechts-Universit\"at zu Kiel}
   \renewcommand{\mypage}{Seite}
   \setboolean{@usegerman}{true}
 }


### PR DESCRIPTION
Christian-Albrechts-Universität zu Kiel